### PR TITLE
Fix Phase 2 backend scripts

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,10 @@ from .routes import (
     drumkit_routes,
     instrument_routes,
     analysis_routes,
+    export_routes,
+    preview_routes,
+    sample_management_routes,
+    xpm_fixer_routes,
 )
 
 app = FastAPI(
@@ -16,8 +20,12 @@ app.include_router(sample_routes.router, prefix="/api", tags=["Samples"])
 app.include_router(drumkit_routes.router, prefix="/api", tags=["Drum Kits"])
 app.include_router(instrument_routes.router, prefix="/api", tags=["Instruments"])
 app.include_router(analysis_routes.router, prefix="/api", tags=["Analysis"])
+app.include_router(preview_routes.router, prefix="/api", tags=["Preview"])
+app.include_router(xpm_fixer_routes.router, prefix="/api", tags=["XPM Fixer"])
+app.include_router(sample_management_routes.router, prefix="/api", tags=["Sample Management"])
+app.include_router(export_routes.router, prefix="/api", tags=["Export"])
 
 
-@app.get("/", tags=["Root"])
+@app.get("/")
 def read_root():
     return {"message": "Welcome to the Live2MPC API"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 librosa
 numpy
 pydantic
+pydub

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,8 +1,21 @@
-from . import sample_routes, drumkit_routes, instrument_routes, analysis_routes
+from . import (
+    sample_routes,
+    drumkit_routes,
+    instrument_routes,
+    analysis_routes,
+    export_routes,
+    preview_routes,
+    sample_management_routes,
+    xpm_fixer_routes,
+)
 
 __all__ = [
     "sample_routes",
     "drumkit_routes",
     "instrument_routes",
     "analysis_routes",
+    "export_routes",
+    "preview_routes",
+    "sample_management_routes",
+    "xpm_fixer_routes",
 ]

--- a/backend/routes/export_routes.py
+++ b/backend/routes/export_routes.py
@@ -1,87 +1,52 @@
-{
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/B0ss-M/Live2MPC/blob/main/backend/routes/export_routes.py\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import os\n",
-        "import shutil\n",
-        "import tempfile\n",
-        "from typing import List\n",
-        "from fastapi import APIRouter, File, UploadFile, Form, HTTPException\n",
-        "from fastapi.responses import FileResponse\n",
-        "from backend.services.export_service import ExportService\n",
-        "\n",
-        "router = APIRouter()\n",
-        "export_service = ExportService()\n",
-        "\n",
-        "@router.post(\"/export-kit/\")\n",
-        "async def export_kit_route(\n",
-        "    xpm_file: UploadFile = File(...),\n",
-        "    sample_files: List[UploadFile] = File(...),\n",
-        "    program_type: str = Form(...),\n",
-        "    program_name: str = Form(...)\n",
-        "):\n",
-        "    \"\"\"\n",
-        "    Accepts an XPM, samples, and settings, then returns a complete, fixed kit as a zip file.\n",
-        "    \"\"\"\n",
-        "    if program_type not in ['instrument', 'drum']:\n",
-        "        raise HTTPException(status_code=400, detail=\"program_type must be 'instrument' or 'drum'\")\n",
-        "\n",
-        "    temp_dir = tempfile.mkdtemp()\n",
-        "    try:\n",
-        "        # Save XPM\n",
-        "        xpm_path = os.path.join(temp_dir, xpm_file.filename)\n",
-        "        with open(xpm_path, \"wb\") as buffer:\n",
-        "            shutil.copyfileobj(xpm_file.file, buffer)\n",
-        "\n",
-        "        # Save Samples\n",
-        "        sample_paths = []\n",
-        "        for sample in sample_files:\n",
-        "            path = os.path.join(temp_dir, sample.filename)\n",
-        "            with open(path, \"wb\") as buffer:\n",
-        "                shutil.copyfileobj(sample.file, buffer)\n",
-        "            sample_paths.append(path)\n",
-        "\n",
-        "        # Create the kit archive\n",
-        "        archive_path = export_service.create_kit_archive(\n",
-        "            xpm_file_path=xpm_path,\n",
-        "            sample_paths=sample_paths,\n",
-        "            program_type=program_type,\n",
-        "            program_name=program_name\n",
-        "        )\n",
-        "\n",
-        "        # The archive is created in a different temp location, so we must clean that up too\n",
-        "        return FileResponse(path=archive_path, media_type='application/zip', filename=f\"{program_name}.zip\", background=lambda: os.remove(archive_path))\n",
-        "    finally:\n",
-        "        shutil.rmtree(temp_dir)"
-      ],
-      "outputs": [],
-      "execution_count": null,
-      "metadata": {
-        "id": "-5ZS-EwwEqbf"
-      }
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
-}
+from fastapi import APIRouter, File, UploadFile, Form, HTTPException
+from fastapi.responses import FileResponse
+from typing import List
+import os
+import shutil
+import tempfile
+
+from ..services.export_service import ExportService
+
+router = APIRouter()
+export_service = ExportService()
+
+
+@router.post("/export-kit/")
+async def export_kit_route(
+    xpm_file: UploadFile = File(...),
+    sample_files: List[UploadFile] = File(...),
+    program_type: str = Form(...),
+    program_name: str = Form(...),
+):
+    """Return a zip archive containing the fixed kit."""
+    if program_type not in {"instrument", "drum"}:
+        raise HTTPException(status_code=400, detail="program_type must be 'instrument' or 'drum'")
+
+    temp_dir = tempfile.mkdtemp()
+    try:
+        xpm_path = os.path.join(temp_dir, xpm_file.filename)
+        with open(xpm_path, "wb") as buffer:
+            shutil.copyfileobj(xpm_file.file, buffer)
+
+        sample_paths = []
+        for sample in sample_files:
+            spath = os.path.join(temp_dir, sample.filename)
+            with open(spath, "wb") as buffer:
+                shutil.copyfileobj(sample.file, buffer)
+            sample_paths.append(spath)
+
+        archive_path = export_service.create_kit_archive(
+            xpm_file_path=xpm_path,
+            sample_paths=sample_paths,
+            program_type=program_type,
+            program_name=program_name,
+        )
+
+        return FileResponse(
+            path=archive_path,
+            media_type="application/zip",
+            filename=f"{program_name}.zip",
+            background=lambda: os.remove(archive_path),
+        )
+    finally:
+        shutil.rmtree(temp_dir)

--- a/backend/routes/preview_routes.py
+++ b/backend/routes/preview_routes.py
@@ -1,87 +1,51 @@
-{
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/B0ss-M/Live2MPC/blob/main/backend/routes/preview_routes.py\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import os\n",
-        "import shutil\n",
-        "import tempfile\n",
-        "from typing import List\n",
-        "from fastapi import APIRouter, File, UploadFile, HTTPException\n",
-        "from fastapi.responses import FileResponse\n",
-        "from backend.services.preview_generator_service import PreviewGeneratorService\n",
-        "\n",
-        "router = APIRouter()\n",
-        "preview_service = PreviewGeneratorService()\n",
-        "\n",
-        "@router.post(\"/generate-preview/\")\n",
-        "async def generate_preview_route(xpm_file: UploadFile = File(...), sample_files: List[UploadFile] = File(...)):\n",
-        "    \"\"\"\n",
-        "    Accepts an XPM file and its samples, then generates and returns an audio preview.\n",
-        "    \"\"\"\n",
-        "    temp_dir = tempfile.mkdtemp()\n",
-        "\n",
-        "    try:\n",
-        "        # Save XPM file\n",
-        "        xpm_file_path = os.path.join(temp_dir, xpm_file.filename)\n",
-        "        with open(xpm_file_path, \"wb\") as buffer:\n",
-        "            shutil.copyfileobj(xpm_file.file, buffer)\n",
-        "\n",
-        "        # Save sample files\n",
-        "        samples_dir = os.path.join(temp_dir, \"samples\")\n",
-        "        os.makedirs(samples_dir)\n",
-        "        for sample_file in sample_files:\n",
-        "            sample_path = os.path.join(samples_dir, sample_file.filename)\n",
-        "            with open(sample_path, \"wb\") as buffer:\n",
-        "                shutil.copyfileobj(sample_file.file, buffer)\n",
-        "\n",
-        "        # Define the output path for the preview\n",
-        "        preview_output_path = os.path.join(temp_dir, \"preview.wav\")\n",
-        "\n",
-        "        # Generate the preview\n",
-        "        success = preview_service.generate_preview(\n",
-        "            xpm_path=xpm_file_path,\n",
-        "            samples_directory=samples_dir,\n",
-        "            output_path=preview_output_path\n",
-        "        )\n",
-        "\n",
-        "        if not success or not os.path.exists(preview_output_path):\n",
-        "            raise HTTPException(status_code=400, detail=\"Failed to generate preview. Check if the XPM and samples are valid.\")\n",
-        "\n",
-        "        # Return the generated preview file\n",
-        "        return FileResponse(path=preview_output_path, media_type='audio/wav', filename=\"preview.wav\", background=lambda: shutil.rmtree(temp_dir))\n",
-        "\n",
-        "    except Exception as e:\n",
-        "        shutil.rmtree(temp_dir)\n",
-        "        raise HTTPException(status_code=500, detail=f\"An unexpected error occurred during preview generation: {str(e)}\")"
-      ],
-      "outputs": [],
-      "execution_count": null,
-      "metadata": {
-        "id": "FVPiUxjwDhfM"
-      }
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
-}
+from fastapi import APIRouter, File, UploadFile, HTTPException
+from fastapi.responses import FileResponse
+from typing import List
+import os
+import shutil
+import tempfile
+
+from ..services.preview_generator_service import PreviewGeneratorService
+
+router = APIRouter()
+preview_service = PreviewGeneratorService()
+
+
+@router.post("/generate-preview/")
+async def generate_preview_route(
+    xpm_file: UploadFile = File(...),
+    sample_files: List[UploadFile] = File(...),
+):
+    """Generate an audio preview from an XPM file and its samples."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+        xpm_path = os.path.join(temp_dir, xpm_file.filename)
+        with open(xpm_path, "wb") as buffer:
+            shutil.copyfileobj(xpm_file.file, buffer)
+
+        samples_dir = os.path.join(temp_dir, "samples")
+        os.makedirs(samples_dir, exist_ok=True)
+        for sample in sample_files:
+            dest = os.path.join(samples_dir, sample.filename)
+            with open(dest, "wb") as buffer:
+                shutil.copyfileobj(sample.file, buffer)
+
+        preview_output = os.path.join(temp_dir, "preview.wav")
+        success = preview_service.generate_preview(
+            xpm_path=xpm_path,
+            samples_directory=samples_dir,
+            output_path=preview_output,
+        )
+
+        if not success or not os.path.exists(preview_output):
+            raise HTTPException(status_code=400, detail="Failed to generate preview")
+
+        return FileResponse(
+            path=preview_output,
+            media_type="audio/wav",
+            filename="preview.wav",
+            background=lambda: shutil.rmtree(temp_dir),
+        )
+    except Exception as e:
+        shutil.rmtree(temp_dir)
+        raise HTTPException(status_code=500, detail=f"An unexpected error occurred during preview generation: {e}")

--- a/backend/routes/sample_management_routes.py
+++ b/backend/routes/sample_management_routes.py
@@ -1,75 +1,39 @@
-{
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/B0ss-M/Live2MPC/blob/main/backend/routes/sample_management_routes.py\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import os\n",
-        "import shutil\n",
-        "import tempfile\n",
-        "from typing import List, Optional\n",
-        "from fastapi import APIRouter, File, UploadFile, Form, HTTPException\n",
-        "from backend.services.sample_management_service import SampleManagementService\n",
-        "\n",
-        "router = APIRouter()\n",
-        "management_service = SampleManagementService()\n",
-        "\n",
-        "@router.post(\"/validate-rename/\")\n",
-        "async def validate_and_rename_route(\n",
-        "    files: List[UploadFile] = File(...),\n",
-        "    program_type: str = Form(...),\n",
-        "    base_name: Optional[str] = Form(None)\n",
-        "):\n",
-        "    \"\"\"\n",
-        "    Accepts samples, validates them, analyzes them, and suggests new names.\n",
-        "    \"\"\"\n",
-        "    if program_type not in ['instrument', 'drum']:\n",
-        "        raise HTTPException(status_code=400, detail=\"program_type must be 'instrument' or 'drum'\")\n",
-        "\n",
-        "    temp_dir = tempfile.mkdtemp()\n",
-        "    sample_paths = []\n",
-        "    try:\n",
-        "        for file in files:\n",
-        "            path = os.path.join(temp_dir, file.filename)\n",
-        "            with open(path, \"wb\") as buffer:\n",
-        "                shutil.copyfileobj(file.file, buffer)\n",
-        "            sample_paths.append(path)\n",
-        "\n",
-        "        results = management_service.validate_and_rename_samples(\n",
-        "            sample_paths=sample_paths,\n",
-        "            program_type=program_type,\n",
-        "            base_name=base_name or \"Instrument\"\n",
-        "        )\n",
-        "        return results\n",
-        "    finally:\n",
-        "        shutil.rmtree(temp_dir)"
-      ],
-      "outputs": [],
-      "execution_count": null,
-      "metadata": {
-        "id": "5fz6JUF2EWU1"
-      }
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
-}
+from fastapi import APIRouter, File, UploadFile, Form, HTTPException
+from typing import List, Optional
+import os
+import shutil
+import tempfile
+
+from ..services.sample_management_service import SampleManagementService
+
+router = APIRouter()
+management_service = SampleManagementService()
+
+
+@router.post("/validate-rename/")
+async def validate_and_rename_route(
+    files: List[UploadFile] = File(...),
+    program_type: str = Form(...),
+    base_name: Optional[str] = Form(None),
+):
+    """Validate samples and suggest new names."""
+    if program_type not in {"instrument", "drum"}:
+        raise HTTPException(status_code=400, detail="program_type must be 'instrument' or 'drum'")
+
+    temp_dir = tempfile.mkdtemp()
+    sample_paths = []
+    try:
+        for file in files:
+            path = os.path.join(temp_dir, file.filename)
+            with open(path, "wb") as buffer:
+                shutil.copyfileobj(file.file, buffer)
+            sample_paths.append(path)
+
+        results = management_service.validate_and_rename_samples(
+            sample_paths=sample_paths,
+            program_type=program_type,
+            base_name=base_name or "Instrument",
+        )
+        return results
+    finally:
+        shutil.rmtree(temp_dir)

--- a/backend/routes/xpm_fixer_routes.py
+++ b/backend/routes/xpm_fixer_routes.py
@@ -1,86 +1,45 @@
-{
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/B0ss-M/Live2MPC/blob/main/backend/routes/xpm_fixer_routes.py\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import os\n",
-        "import shutil\n",
-        "import tempfile\n",
-        "from typing import List\n",
-        "from fastapi import APIRouter, File, UploadFile, HTTPException, Form\n",
-        "from fastapi.responses import FileResponse\n",
-        "from backend.services.xpm_fixer_service import XpmFixerService\n",
-        "\n",
-        "router = APIRouter()\n",
-        "fixer_service = XpmFixerService()\n",
-        "\n",
-        "@router.post(\"/fix-xpm/\")\n",
-        "async def fix_xpm_route(xpm_file: UploadFile = File(...), sample_files: List[UploadFile] = File(...)):\n",
-        "    \"\"\"\n",
-        "    Accepts an XPM file and a list of sample files.\n",
-        "    It attempts to fix the sample paths in the XPM file and returns the corrected version.\n",
-        "    \"\"\"\n",
-        "    # Create a temporary directory to work in\n",
-        "    temp_dir = tempfile.mkdtemp()\n",
-        "\n",
-        "    try:\n",
-        "        # Save the uploaded XPM file to the temp directory\n",
-        "        xpm_file_path = os.path.join(temp_dir, xpm_file.filename)\n",
-        "        with open(xpm_file_path, \"wb\") as buffer:\n",
-        "            shutil.copyfileobj(xpm_file.file, buffer)\n",
-        "\n",
-        "        # Create a subdirectory for samples\n",
-        "        samples_dir = os.path.join(temp_dir, \"samples\")\n",
-        "        os.makedirs(samples_dir)\n",
-        "\n",
-        "        # Save all uploaded sample files into the samples subdirectory\n",
-        "        for sample_file in sample_files:\n",
-        "            sample_path = os.path.join(samples_dir, sample_file.filename)\n",
-        "            with open(sample_path, \"wb\") as buffer:\n",
-        "                shutil.copyfileobj(sample_file.file, buffer)\n",
-        "\n",
-        "        # Call the fixer service\n",
-        "        fixed_xpm_path = fixer_service.fix_xpm(xpm_path=xpm_file_path, samples_directory=samples_dir)\n",
-        "\n",
-        "        # Return the fixed file and clean up afterwards\n",
-        "        return FileResponse(path=fixed_xpm_path, media_type='application/xml', filename=os.path.basename(fixed_xpm_path), background=lambda: shutil.rmtree(temp_dir))\n",
-        "\n",
-        "    except ValueError as e:\n",
-        "        # Clean up the temp directory in case of a known error\n",
-        "        shutil.rmtree(temp_dir)\n",
-        "        raise HTTPException(status_code=400, detail=str(e))\n",
-        "    except Exception as e:\n",
-        "        # Clean up the temp directory in case of an unexpected error\n",
-        "        shutil.rmtree(temp_dir)\n",
-        "        raise HTTPException(status_code=500, detail=f\"An unexpected error occurred: {str(e)}\")"
-      ],
-      "outputs": [],
-      "execution_count": null,
-      "metadata": {
-        "id": "SDmRkxqFC08j"
-      }
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
-}
+from fastapi import APIRouter, File, UploadFile, HTTPException
+from fastapi.responses import FileResponse
+from typing import List
+import os
+import shutil
+import tempfile
+
+from ..services.xpm_fixer_service import XpmFixerService
+
+router = APIRouter()
+fixer_service = XpmFixerService()
+
+
+@router.post("/fix-xpm/")
+async def fix_xpm_route(
+    xpm_file: UploadFile = File(...),
+    sample_files: List[UploadFile] = File(...),
+):
+    """Fix broken sample paths in an uploaded XPM file."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+        xpm_path = os.path.join(temp_dir, xpm_file.filename)
+        with open(xpm_path, "wb") as buffer:
+            shutil.copyfileobj(xpm_file.file, buffer)
+
+        samples_dir = os.path.join(temp_dir, "samples")
+        os.makedirs(samples_dir, exist_ok=True)
+        for sample in sample_files:
+            dest = os.path.join(samples_dir, sample.filename)
+            with open(dest, "wb") as buffer:
+                shutil.copyfileobj(sample.file, buffer)
+
+        fixed_path = fixer_service.fix_xpm(xpm_path=xpm_path, samples_directory=samples_dir)
+        return FileResponse(
+            path=fixed_path,
+            media_type="application/xml",
+            filename=os.path.basename(fixed_path),
+            background=lambda: shutil.rmtree(temp_dir),
+        )
+    except ValueError as e:
+        shutil.rmtree(temp_dir)
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        shutil.rmtree(temp_dir)
+        raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {e}")

--- a/backend/services/export_service.py
+++ b/backend/services/export_service.py
@@ -1,0 +1,37 @@
+import os
+import shutil
+import tempfile
+import zipfile
+from typing import List
+
+
+class ExportService:
+    """Create kit archives from XPM files and samples."""
+
+    def create_kit_archive(
+        self,
+        xpm_file_path: str,
+        sample_paths: List[str],
+        program_type: str,
+        program_name: str,
+    ) -> str:
+        temp_dir = tempfile.mkdtemp()
+        kit_dir = os.path.join(temp_dir, program_name)
+        os.makedirs(kit_dir, exist_ok=True)
+
+        shutil.copy(xpm_file_path, os.path.join(kit_dir, os.path.basename(xpm_file_path)))
+        samples_dir = os.path.join(kit_dir, "samples")
+        os.makedirs(samples_dir, exist_ok=True)
+
+        for path in sample_paths:
+            shutil.copy(path, os.path.join(samples_dir, os.path.basename(path)))
+
+        archive_path = os.path.join(temp_dir, f"{program_name}.zip")
+        with zipfile.ZipFile(archive_path, "w") as zf:
+            for root, _, files in os.walk(kit_dir):
+                for f in files:
+                    full_path = os.path.join(root, f)
+                    zf.write(full_path, arcname=os.path.relpath(full_path, kit_dir))
+
+        shutil.rmtree(kit_dir)
+        return archive_path

--- a/backend/services/preview_generator_service.py
+++ b/backend/services/preview_generator_service.py
@@ -1,0 +1,47 @@
+import os
+import xml.etree.ElementTree as ET
+from typing import List, Tuple
+from pydub import AudioSegment
+
+
+class PreviewGeneratorService:
+    """Generate simple audio previews for MPC programs."""
+
+    def _get_samples_from_xpm(self, xpm_path: str, samples_directory: str) -> List[Tuple[int, str]]:
+        samples: List[Tuple[int, str]] = []
+        try:
+            tree = ET.parse(xpm_path)
+            root = tree.getroot()
+            for layer in root.findall('.//{http://www.akaipro.com/xpm}Layer'):
+                sample_el = layer.find('{http://www.akaipro.com/xpm}sampleFileName')
+                root_note_el = layer.find('{http://www.akaipro.com/xpm}rootNote')
+                if sample_el is not None and sample_el.text and root_note_el is not None:
+                    sample_filename = os.path.basename(sample_el.text)
+                    sample_path = os.path.join(samples_directory, sample_filename)
+                    if os.path.exists(sample_path):
+                        samples.append((int(root_note_el.text), sample_path))
+            samples.sort()
+            return samples
+        except ET.ParseError:
+            return []
+
+    def generate_preview(self, xpm_path: str, samples_directory: str, output_path: str) -> bool:
+        program_samples = self._get_samples_from_xpm(xpm_path, samples_directory)
+        if not program_samples:
+            return False
+
+        samples_to_sequence = program_samples[:4]
+        step_duration_ms = 500
+        preview = AudioSegment.silent(duration=len(samples_to_sequence) * step_duration_ms)
+
+        for i, (_, sample_path) in enumerate(samples_to_sequence):
+            try:
+                sample_audio = AudioSegment.from_file(sample_path)
+                preview = preview.overlay(sample_audio, position=i * step_duration_ms)
+            except Exception:
+                continue
+
+        if preview.duration_seconds > 0:
+            preview.export(output_path, format="wav")
+            return True
+        return False

--- a/backend/services/sample_management_service.py
+++ b/backend/services/sample_management_service.py
@@ -1,0 +1,62 @@
+import os
+import re
+from typing import List, Dict, Any
+
+from .sample_analyzer_service import SampleAnalyzerService, SampleAnalysis
+
+
+class SampleManagementService:
+    """Validate and rename samples based on their content and type."""
+
+    def __init__(self) -> None:
+        self.analyzer = SampleAnalyzerService()
+
+    def _sanitize_filename(self, name: str) -> str:
+        name = re.sub(r"[^\w\s.-]", "", name)
+        return re.sub(r"\s+", "_", name)
+
+    def _create_instrument_name(self, base_name: str, analysis: SampleAnalysis, original_filename: str) -> str:
+        if analysis.pitch:
+            safe_pitch = analysis.pitch.replace("#", "sharp")
+            extension = os.path.splitext(original_filename)[1]
+            return f"{base_name}_{safe_pitch}{extension}"
+        return self._sanitize_filename(original_filename)
+
+    def validate_and_rename_samples(
+        self,
+        sample_paths: List[str],
+        program_type: str,
+        base_name: str = "Instrument",
+    ) -> List[Dict[str, Any]]:
+        results = []
+        for sample_path in sample_paths:
+            original_filename = os.path.basename(sample_path)
+            report = {"original_filename": original_filename, "valid": True, "errors": []}
+
+            if not os.path.exists(sample_path):
+                report["valid"] = False
+                report["errors"].append("File not found.")
+                results.append(report)
+                continue
+
+            if not original_filename.lower().endswith(".wav"):
+                report["valid"] = False
+                report["errors"].append("Invalid format: not a .wav file.")
+
+            analysis = self.analyzer.analyze_sample(sample_path)
+            if not analysis.pitch and program_type == "instrument":
+                report["errors"].append("Warning: Could not detect pitch for instrument sample.")
+
+            new_name = (
+                self._create_instrument_name(base_name, analysis, original_filename)
+                if program_type == "instrument"
+                else self._sanitize_filename(original_filename)
+            )
+
+            results.append({
+                "original_filename": original_filename,
+                "new_filename": new_name,
+                "analysis": analysis.dict(),
+                "validation": report,
+            })
+        return results

--- a/backend/services/xpm_fixer_service.py
+++ b/backend/services/xpm_fixer_service.py
@@ -1,0 +1,39 @@
+import os
+import xml.etree.ElementTree as ET
+from typing import List
+
+
+class XpmFixerService:
+    """Fix broken sample paths in MPC .xpm program files."""
+
+    def fix_xpm(self, xpm_path: str, samples_directory: str) -> str:
+        """Parse an XPM file and correct sample paths using files from ``samples_directory``.
+
+        Returns path to the fixed XPM file.
+        """
+        try:
+            ET.register_namespace("Akai", "http://www.akaipro.com/xpm")
+            tree = ET.parse(xpm_path)
+            root = tree.getroot()
+
+            available = {
+                f: os.path.join(samples_directory, f)
+                for f in os.listdir(samples_directory)
+                if os.path.isfile(os.path.join(samples_directory, f))
+            }
+
+            for layer in root.findall('.//{http://www.akaipro.com/xpm}Layer'):
+                el = layer.find('{http://www.akaipro.com/xpm}sampleFileName')
+                if el is not None and el.text:
+                    base = os.path.basename(el.text)
+                    if not os.path.exists(el.text) and base in available:
+                        el.text = base
+
+            directory, original = os.path.split(xpm_path)
+            fixed_path = os.path.join(directory, f"{os.path.splitext(original)[0]}_fixed.xpm")
+            tree.write(fixed_path, encoding="utf-8", xml_declaration=True)
+            return fixed_path
+        except ET.ParseError as e:
+            raise ValueError(f"Could not parse the XPM file: {xpm_path}") from e
+        except Exception as e:
+            raise


### PR DESCRIPTION
## Summary
- convert all Phase 2 route stubs from Colab JSON to runnable Python
- implement supporting services for XPM fixing, preview generation, sample management and kit export
- wire new routers into FastAPI
- add pydub dependency

## Testing
- `python -m py_compile $(git ls-files "backend/**/*.py")`


------
https://chatgpt.com/codex/tasks/task_e_686981b60884832bb85fc26f894deddd