### PR TITLE
Fix Java checker logic and document tasks

### DIFF
--- a/AGENT_TASKS.md
+++ b/AGENT_TASKS.md
@@ -24,3 +24,17 @@ This document outlines the tasks for the A.I. developer agents building the Live
 * \[ \] Advanced fixer logic and preview rendering  
 * \[ \] Batch automation tools and CLI support  
 * \[ \] UI polish and full MPC-style interaction
+
+## **Ongoing Coordination**
+
+### Tasks for @Codex
+
+* [x] Add API route `/api/check-java` to verify Java installation
+* [x] Update frontend Java converter to use the new API
+
+### Tasks for @Live2MPC
+
+* [ ] Implement Expansion Builder producing `expansion.xml`
+* [ ] Enhance preview rendering with advanced logic
+* [ ] Develop batch automation CLI tools
+* [ ] Continue UI polish for MPC-style interaction

--- a/app/api/check-java/route.ts
+++ b/app/api/check-java/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { exec } from "child_process";
+import util from "util";
+
+const execAsync = util.promisify(exec);
+
+export async function GET() {
+  try {
+    await execAsync("java -version");
+    return NextResponse.json({ installed: true });
+  } catch {
+    return NextResponse.json({ installed: false });
+  }
+}

--- a/components/java-converter-view.tsx
+++ b/components/java-converter-view.tsx
@@ -3,7 +3,6 @@
 import type React from "react"
 import { useState, useRef, useEffect } from "react"
 import { checkJavaInstallation } from "@/lib/utils/java-checker"
-import { platform } from "os"
 
 export default function JavaConverterView() {
   const [file, setFile] = useState<File | null>(null)
@@ -26,8 +25,12 @@ export default function JavaConverterView() {
 
     checkJava()
 
-    // Detect operating system
-    setCurrentOS(platform())
+    // Detect operating system using browser navigator
+    const ua = navigator.userAgent
+    if (ua.includes("Win")) setCurrentOS("Windows")
+    else if (ua.includes("Mac")) setCurrentOS("macOS")
+    else if (ua.includes("Linux")) setCurrentOS("Linux")
+    else setCurrentOS("Unknown")
   }, [])
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/lib/utils/java-checker.ts
+++ b/lib/utils/java-checker.ts
@@ -1,22 +1,10 @@
-import { exec } from "child_process"
-import { dialog } from "electron"
-
 export async function checkJavaInstallation(): Promise<boolean> {
-  return new Promise((resolve) => {
-    exec("java -version", (error) => {
-      if (error) {
-        dialog.showMessageBox({
-          type: "warning",
-          title: "Java Not Found",
-          message: "Java is required to use the conversion features.",
-          detail:
-            "Please install Java and restart the application.\n\nYou can download Java from: https://www.java.com/download/",
-          buttons: ["OK"],
-        })
-        resolve(false)
-      } else {
-        resolve(true)
-      }
-    })
-  })
+  try {
+    const res = await fetch("/api/check-java");
+    if (!res.ok) return false;
+    const data = await res.json();
+    return !!data.installed;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- add server API route for checking Java installation
- call the new API from the Java converter view
- remove Node/Electron usage from the browser
- document next tasks for Codex and Live2MPC agents

## Testing
- `pnpm run build` *(fails: Electron failed to install correctly)*

------
https://chatgpt.com/codex/tasks/task_e_68698c124f2c832b82c2f1e81b9f43a8